### PR TITLE
Fix Ad height to comply with admob policy

### DIFF
--- a/admobadapter/build.gradle
+++ b/admobadapter/build.gradle
@@ -18,7 +18,7 @@ android {
     buildToolsVersion "24.0.1"
 
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 9
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
@@ -29,7 +29,7 @@ public class AdViewHelper {
         adView.setAdSize(adSize);
         adView.setAdUnitId(adsUnitId);
         adView.setLayoutParams(new AbsListView.LayoutParams(AbsListView.LayoutParams.MATCH_PARENT,
-                AbsListView.LayoutParams.WRAP_CONTENT));
+                adSize.getHeightInPixels(context)));
         return adView;
     }
 

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobFetcherBase.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobFetcherBase.java
@@ -123,16 +123,18 @@ public abstract class AdmobFetcherBase {
      */
     protected void notifyObserversOfAdSizeChange(final int adIdx) {
         Context context = mContext.get();
-        new Handler(context.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                for (AdmobListener listener : mAdNativeListeners)
-                    if(adIdx < 0)
-                        listener.onAdChanged();
-                    else listener.onAdChanged(adIdx);
-            }
-        });
-
+        //context may be null if activity is destroyed
+        if(context != null) {
+            new Handler(context.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    for (AdmobListener listener : mAdNativeListeners)
+                        if(adIdx < 0)
+                            listener.onAdChanged();
+                        else listener.onAdChanged(adIdx);
+                }
+            });
+        }
     }
 
     /**

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
@@ -113,6 +113,7 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 // Handle the failure by logging, altering the UI, etc.
                 Log.i(TAG, "onAdFailedToLoad " + errorCode);
                 mFetchFailCount++;
+                mNoOfFetchedAds--;
             }
 
             @Override
@@ -121,6 +122,7 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 onAdFetched(adView);
             }
         });
+        notifyObserversOfAdSizeChange(mNoOfFetchedAds++);
     }
 
     /**
@@ -129,9 +131,6 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
      */
     private synchronized void onAdFetched(NativeExpressAdView adNative) {
         Log.i(TAG, "onAdFetched");
-        if (canUseThisAd(adNative)) {
-            notifyObserversOfAdSizeChange(mNoOfFetchedAds++);
-        }
         mFetchFailCount = 0;
     }
 

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
@@ -20,6 +20,7 @@ package com.clockbyte.admobadapter.expressads;
 import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
+import android.view.View;
 
 import com.clockbyte.admobadapter.AdmobFetcherBase;
 import com.google.android.gms.ads.AdListener;
@@ -113,7 +114,15 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 // Handle the failure by logging, altering the UI, etc.
                 Log.i(TAG, "onAdFailedToLoad " + errorCode);
                 mFetchFailCount++;
-                mNoOfFetchedAds--;
+                //Since Fetch Ad is only called once without retries
+                //hide ad row or rollback its count if still not added to list
+                //best approach to work with custom adapters that cache their views
+                if(adView.getParent()==null){
+                    mNoOfFetchedAds--;
+                    notifyObserversOfAdSizeChange(mNoOfFetchedAds);
+                }else {
+                    ((View) adView.getParent()).setVisibility(View.GONE);
+                }
             }
 
             @Override


### PR DESCRIPTION
As mentioned before, it is against admob/adsense policy to change layout after ads are loaded so it doesn't drive any mistaken clicks or interactions.
So basically, here is in summary what was done:
1- set NativeExpressAdView layout height to the adSize's height
2- notify dataset change right after ad setup and not after ad loaded
3- hide ad list row in case of ad load failure

Also, project is compatible with minSdkVersion 9