### PR TITLE
multi unit ids support for both Listviews and recycler views

### DIFF
--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
@@ -19,6 +19,7 @@ package com.clockbyte.admobadapter;
 import android.content.Context;
 import android.widget.AbsListView;
 
+import com.clockbyte.admobadapter.expressads.NativeExpressAd;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.NativeExpressAdView;
 
@@ -30,6 +31,17 @@ public class AdViewHelper {
         adView.setAdUnitId(adsUnitId);
         adView.setLayoutParams(new AbsListView.LayoutParams(AbsListView.LayoutParams.MATCH_PARENT,
                 adSize.getHeightInPixels(context)));
+        return adView;
+    }
+    
+    
+    public static NativeExpressAdView getExpressAdView(Context context, NativeExpressAd nativeExpressAd) {
+        NativeExpressAdView adView = new NativeExpressAdView(context);
+        AdSize adSize = nativeExpressAd.getAdSize();
+        adView.setAdSize(adSize);
+        adView.setAdUnitId(nativeExpressAd.getAdUnitId());
+        adView.setLayoutParams(new AbsListView.LayoutParams(AbsListView.LayoutParams.MATCH_PARENT,
+        adSize.getHeightInPixels(context)));
         return adView;
     }
 

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdViewHelper.java
@@ -29,7 +29,7 @@ public class AdViewHelper {
         adView.setAdSize(adSize);
         adView.setAdUnitId(adsUnitId);
         adView.setLayoutParams(new AbsListView.LayoutParams(AbsListView.LayoutParams.MATCH_PARENT,
-                AbsListView.LayoutParams.WRAP_CONTENT));
+                adSize.getHeightInPixels(context)));
         return adView;
     }
 

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobFetcherBase.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobFetcherBase.java
@@ -123,16 +123,18 @@ public abstract class AdmobFetcherBase {
      */
     protected void notifyObserversOfAdSizeChange(final int adIdx) {
         Context context = mContext.get();
-        new Handler(context.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                for (AdmobListener listener : mAdNativeListeners)
-                    if(adIdx < 0)
-                        listener.onAdChanged();
-                    else listener.onAdChanged(adIdx);
-            }
-        });
-
+        //context may be null if activity is destroyed
+        if(context != null) {
+            new Handler(context.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    for (AdmobListener listener : mAdNativeListeners)
+                        if(adIdx < 0)
+                            listener.onAdChanged();
+                        else listener.onAdChanged(adIdx);
+                }
+            });
+        }
     }
 
     /**

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobExpressAdapterWrapper.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobExpressAdapterWrapper.java
@@ -319,6 +319,10 @@ public class AdmobExpressAdapterWrapper extends BaseAdapter implements AdmobFetc
      */
     public AdmobExpressAdapterWrapper(Context context, ArrayList<NativeExpressAd> admobNativeExpressAds, String[] testDevicesId) {
         initMultiple(context, admobNativeExpressAds, testDevicesId);
+    }    
+    
+    public AdmobExpressAdapterWrapper(Context context, ArrayList<NativeExpressAd> admobNativeExpressAds) {
+        initMultiple(context, admobNativeExpressAds, null);
     }
 
     private void init(Context context, Collection<String> admobReleaseUnitIds, String[] testDevicesId, AdSize adSize) {

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobExpressAdapterWrapper.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobExpressAdapterWrapper.java
@@ -86,6 +86,7 @@ public class AdmobExpressAdapterWrapper extends BaseAdapter implements AdmobFetc
     private final static int DEFAULT_NO_OF_DATA_BETWEEN_ADS = 10;
     private final static int DEFAULT_LIMIT_OF_ADS = 3;
     private static final AdSize DEFAULT_AD_SIZE = new AdSize(AdSize.FULL_WIDTH, 150);
+    private static final String DEFAULT_AD_UNIT_ID = "ca-app-pub-3940256099942544/1072772517";
     
     public int getNativeAdUnitsCount(){
         return this.mNativeExpressAds.size();
@@ -147,6 +148,7 @@ public class AdmobExpressAdapterWrapper extends BaseAdapter implements AdmobFetc
         AdapterCalculator.setLimitOfAds(mLimitOfAds);
     }
 
+    private String mAdsUnitId;
     private AdSize mAdSize;  
     
     private ArrayList<NativeExpressAd> mNativeExpressAds = new ArrayList<NativeExpressAd>();

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
@@ -113,6 +113,7 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 // Handle the failure by logging, altering the UI, etc.
                 Log.i(TAG, "onAdFailedToLoad " + errorCode);
                 mFetchFailCount++;
+                mNoOfFetchedAds--;
             }
 
             @Override
@@ -121,6 +122,7 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 onAdFetched(adView);
             }
         });
+        notifyObserversOfAdSizeChange(mNoOfFetchedAds++);
     }
 
     /**
@@ -129,9 +131,6 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
      */
     private synchronized void onAdFetched(NativeExpressAdView adNative) {
         Log.i(TAG, "onAdFetched");
-        if (canUseThisAd(adNative)) {
-            notifyObserversOfAdSizeChange(mNoOfFetchedAds++);
-        }
         mFetchFailCount = 0;
     }
 

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/AdmobFetcherExpress.java
@@ -20,6 +20,7 @@ package com.clockbyte.admobadapter.expressads;
 import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
+import android.view.View;
 
 import com.clockbyte.admobadapter.AdmobFetcherBase;
 import com.google.android.gms.ads.AdListener;
@@ -113,7 +114,15 @@ public class AdmobFetcherExpress extends AdmobFetcherBase {
                 // Handle the failure by logging, altering the UI, etc.
                 Log.i(TAG, "onAdFailedToLoad " + errorCode);
                 mFetchFailCount++;
-                mNoOfFetchedAds--;
+                //Since Fetch Ad is only called once without retries
+                //hide ad row or rollback its count if still not added to list
+                //best approach to work with custom adapters that cache their views
+                if(adView.getParent()==null){
+                    mNoOfFetchedAds--;
+                    notifyObserversOfAdSizeChange(mNoOfFetchedAds);
+                }else {
+                    ((View) adView.getParent()).setVisibility(View.GONE);
+                }
             }
 
             @Override

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2015 Yahoo Inc. All rights reserved.
+ * Copyright 2015 Clockbyte LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clockbyte.admobadapter.expressads;
+
+
+import android.text.TextUtils;
+
+import com.google.android.gms.ads.AdSize;
+
+public class NativeExpressAd {
+    private String adUnitId;
+    private AdSize adSize;
+
+    public NativeExpressAd(){
+        this.adUnitId = "ca-app-pub-3940256099942544/1072772517";
+        this.adSize = new AdSize(AdSize.FULL_WIDTH, 150);
+    }
+
+    public NativeExpressAd(String adUnitId){
+        this.adUnitId = adUnitId;
+        this.adSize = new AdSize(AdSize.FULL_WIDTH, 150);
+    }
+
+    public NativeExpressAd(String adUnitId, AdSize adSize){
+        this.adUnitId = adUnitId;
+        this.adSize = adSize;
+    }
+
+    public String getAdUnitId(){
+        return this.adUnitId;
+    }
+
+    public void setAdUnitId(String adUnitId){
+        this.adUnitId = adUnitId;
+    }
+
+    public AdSize getAdSize(){
+        return this.adSize;
+    }
+
+    public void setAdUnitId(AdSize adSize){
+        this.adSize = adSize;
+    }
+
+    public boolean isValid(){
+        return !TextUtils.isEmpty(this.adUnitId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof NativeExpressAd) {
+            NativeExpressAd other = (NativeExpressAd) o;
+            return (this.adUnitId == other.adUnitId && this.adSize.getHeight() == other.adSize.getHeight() && this.adSize.getWidth() == other.adSize.getWidth());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.adUnitId.hashCode() + this.adSize.hashCode();
+    }
+
+}

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
@@ -72,7 +72,13 @@ public class NativeExpressAd {
 
     @Override
     public int hashCode() {
-        return this.adUnitId.hashCode() + this.adSize.hashCode();
+        int hash = 17;
+        hash = hash * 31 + adUnitId.hashCode();
+        hash = hash * 31 + adSize.hashCode();
+        if(adListener != null){
+            hash = hash * 31 + adListener.hashCode();
+        }
+        return hash;
     }
 
 }

--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/expressads/NativeExpressAd.java
@@ -75,9 +75,6 @@ public class NativeExpressAd {
         int hash = 17;
         hash = hash * 31 + adUnitId.hashCode();
         hash = hash * 31 + adSize.hashCode();
-        if(adListener != null){
-            hash = hash * 31 + adListener.hashCode();
-        }
         return hash;
     }
 


### PR DESCRIPTION
First of all, I adjusted code as suggested:

1. removed the constraint on user to provide only unique NativeExpressAd Objects, since reusing the same ad view is not yet implemented.
2. adjusted hashcode method according to the best practice example that was provided
3. also, I added support for multi NativeExpressAds in AdmobRecyclerAdapterWrapper (but please note that this was not tested on device)