### PR TITLE
Fix issue when failed admob requests are < 0

### DIFF
--- a/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobAdapterCalculator.java
+++ b/admobadapter/src/main/java/com/clockbyte/admobadapter/AdmobAdapterCalculator.java
@@ -79,7 +79,7 @@ public class AdmobAdapterCalculator {
      * @return the original position that the adapter position would have been without ads
      */
     public int getAdsCountToPublish(int fetchedAdsCount, int sourceItemsCount){
-        if(fetchedAdsCount == 0 || getNoOfDataBetweenAds() == 0) return 0;
+        if(fetchedAdsCount <= 0 || getNoOfDataBetweenAds() <= 0) return 0;
         int expected = 0;
         if(sourceItemsCount > 0 && sourceItemsCount >= getOffsetValue()+1)
             expected = (sourceItemsCount - getOffsetValue()) / getNoOfDataBetweenAds() + 1;


### PR DESCRIPTION
Hello clockbyte and thank you for the great repo.

I see you released a new release yesterday but unfortunately very major for use issue is still not working. Talking about this one: https://github.com/clockbyte/admobadapter/issues/49 

I fix the issue and if I can kindly request to accept my pull request and push another release. 

I still dont have explanation why more ad request fails that were actually send but it is fact that fetchedAdsCount is read with value -1 when list item is clicked at the end it opens the next list item but not the selected one.

Thanks. 