### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Admob Adapter is an Android library that makes it easy to integrate [Admob nativ
 
 You can read the rest info (main features, base usage and so on) at the [project's home page](https://github.com/clockbyte/admobadapter/wiki/Home) if you wish.
 
-#Installation
+# Installation
 Now you are able to link Admobadapter via Gradle like this
 ```shell
 dependencies {
@@ -24,7 +24,7 @@ dependencies {
 ```
 [Here](https://github.com/clockbyte/admobadapter/wiki/Installation) you could find more ways.
 
-#Apps which use Admobadapter
+# Apps which use Admobadapter
 
 [**Snoop VK**](https://play.google.com/store/apps/details?id=com.clockbyte.vkgroupwatcher) | [**Mourjan.com**](https://play.google.com/store/apps/details?id=com.mourjan.classifieds)
 --- | ---
@@ -32,5 +32,5 @@ dependencies {
 
 **If you use/going to use the Admobadapter for your application and also you want your application's logo to be here please let us know with a new issue.**
 
-#Contributions
+# Contributions
 Contributions are very welcome. If you find a bug in the library or want an improvement and feel you can work on it yourself, fork + pull request and i'll appreciate it much!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
